### PR TITLE
ARTEMIS-5425 - Compile console with java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 17, 21 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
     <url>https://activemq.apache.org/components/artemis/</url>
 
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
         <hawtio.version>4.4.0</hawtio.version>
         <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
         <slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION
ArtemisMQ only supports java 17+, so we can drop java11 from console as well