### PR TITLE
ARTEMIS-5495: jakarta.servlet-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.release>17</maven.compiler.release>
         <hawtio.version>4.4.0</hawtio.version>
-        <jakarta.servlet-api.version>5.0.0</jakarta.servlet-api.version>
+        <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
         <slf4j.version>2.0.17</slf4j.version>
         <log4j.version>2.24.3</log4j.version>
         <jetty-version>11.0.24</jetty-version>


### PR DESCRIPTION
Bumping jakarta.servlet-api.version to latest version (compiled with java 11 as opposed to 1.8).
