### PR TITLE
ARTEMIS-5569 Include Monaco editor scripts locally

### DIFF
--- a/artemis-console-extension/artemis-extension/packages/artemis-console-plugin/src/messages/SendMessage.tsx
+++ b/artemis-console-extension/artemis-extension/packages/artemis-console-plugin/src/messages/SendMessage.tsx
@@ -16,6 +16,7 @@
  */
 import React, { FormEvent, useRef, useState } from 'react'
 import * as monacoEditor from 'monaco-editor'
+import { monacoLoader } from '@monaco-editor/react'
 import xmlFormat from 'xml-formatter'
 
 import {
@@ -44,6 +45,8 @@ import { CodeEditor, Language } from '@patternfly/react-code-editor'
 import { eventService } from '@hawtio/react'
 import { artemisService } from '../artemis-service'
 import { Message } from './MessageView'
+
+monacoLoader.config({ monacoEditor })
 
 type SendBodyMessageProps = {
   onBodyChange: (body: string) => void


### PR DESCRIPTION
This should fix an issue reported on the mailing list, where Monaco Editor resources are loaded from CDN and thus blocked by CSP policy.